### PR TITLE
役職作成時の色をランダムにする

### DIFF
--- a/discordbot.py
+++ b/discordbot.py
@@ -1,3 +1,4 @@
+from random import randint
 import os
 import traceback
 import discord
@@ -14,7 +15,12 @@ async def requires_admin(message, func):
 
 async def create_role(message):
     arg = message.content.split('/create_role ')[1]
-    await client.create_role(message.server, name=arg, mentionable=True)
+    await client.create_role(
+        message.server,
+        name=arg,
+        mentionable=True,
+        color=discord.Colour(generate_random_color()),
+    )
     return '役職 {} を作成しました'.format(arg)
 
 
@@ -76,6 +82,11 @@ def is_common(role):
 
 def get_role_names(roles, requirements):
     return [r.name for r in roles if requirements(r)]
+
+
+def generate_random_color():
+    rgb = [randint(0, 255) for _ in range(3)]
+    return int('0x{:X}{:X}{:X}'.format(*rgb), 16)
 
 
 async def run_command(message):


### PR DESCRIPTION
- [6.1. string — 一般的な文字列操作 — Python 3.6.5 ドキュメント](https://docs.python.jp/3/library/string.html#string.Formatter)
- [2. 組み込み関数 — Python 3.6.5 ドキュメント](https://docs.python.jp/3/library/functions.html?highlight=int#int)
- [Colour | API Reference — discord.py 0.16.12 documentation](http://discordpy.readthedocs.io/en/latest/api.html#colour)
- [create_role | API Reference — discord.py 0.16.12 documentation](http://discordpy.readthedocs.io/en/latest/api.html#discord.Client.create_role)
- [edit_role | API Reference — discord.py 0.16.12 documentation](http://discordpy.readthedocs.io/en/latest/api.html#discord.Client.edit_role)
- [Python Tips：Python で 16/256 階調 RGB カラーをランダムに出力したい - Life with Python](https://www.lifewithpython.com/2015/03/generate-random-color-with-python.html)