### PR TITLE
型アノテーションとPyAnnotateの導入

### DIFF
--- a/discordbot.py
+++ b/discordbot.py
@@ -1,3 +1,7 @@
+from discord.message import Message
+from discord.embeds import Embed
+from discord.role import Role
+from typing import Callable, List
 from random import randint
 import os
 import traceback
@@ -7,13 +11,13 @@ client = discord.Client()
 debug_mode = False
 
 
-async def requires_admin(message, func):
+async def requires_admin(message: Message, func: Callable) -> str:
     if message.author.server_permissions.administrator:
         return await func(message)
     return 'コマンドを実行する権限がありません'
 
 
-async def create_role(message):
+async def create_role(message: Message) -> str:
     arg = message.content.split('/create_role ')[1]
     if arg.lower() in [role.name.lower() for role in message.server.roles]:
         return 'その役職は既に存在します'
@@ -26,7 +30,7 @@ async def create_role(message):
     return '役職 {} を作成しました'.format(arg)
 
 
-async def delete_role(message):
+async def delete_role(message: Message) -> str:
     arg = message.content.split('/delete_role ')[1].lower()
     role_names = [role.name.lower() for role in message.server.roles]
     if arg in role_names:
@@ -37,13 +41,13 @@ async def delete_role(message):
     return '役職 {} は存在しません'.format(arg)
 
 
-def toggle_debug_mode(mode):
+def toggle_debug_mode(mode: bool) -> str:
     global debug_mode
     debug_mode = mode
     return 'デバッグモードを{}にしました'.format('ON' if mode else 'OFF')
 
 
-async def set_roles(message):
+async def set_roles(message: Message) -> str:
     add, rm, pd, nt = [], [], [], []
     role_names = [role.name.lower() for role in message.server.roles]
     for role_name in message.content.split()[1:]:
@@ -72,7 +76,7 @@ async def set_roles(message):
     return msg
 
 
-def is_common(role):
+def is_common(role: Role) -> bool:
     if role.is_everyone:
         return False
     if role.managed:
@@ -82,16 +86,16 @@ def is_common(role):
     return True
 
 
-def get_role_names(roles, requirements):
+def get_role_names(roles: List[Role], requirements: Callable) -> List[str]:
     return [r.name for r in roles if requirements(r)]
 
 
-def generate_random_color():
+def generate_random_color() -> int:
     rgb = [randint(0, 255) for _ in range(3)]
     return int('0x{:X}{:X}{:X}'.format(*rgb), 16)
 
 
-def get_help():
+def get_help() -> Embed:
     """コマンドの一覧と詳細をembedで返す"""
     helps = {
         '`/role`':
@@ -123,7 +127,7 @@ def get_help():
     return embed
 
 
-async def run_command(message):
+async def run_command(message: Message) -> None:
     msg, embed = None, None
     remark = message.content
     if remark == '/role':
@@ -166,12 +170,13 @@ async def run_command(message):
 
 
 @client.event
-async def on_ready():
+async def on_ready() -> None:
     print('Logged in')
     await client.edit_profile(username="Echidna")
 
+
 @client.event
-async def on_message(message):
+async def on_message(message: Message) -> None:
     try:
         if message.author == client.user:
             return
@@ -187,4 +192,10 @@ async def on_message(message):
     finally:
         pass
 
-client.run(os.environ['DISCORD_BOT_TOKEN'])
+
+def main() -> None:
+    client.run(os.environ['DISCORD_BOT_TOKEN'])
+
+
+if __name__ == '__main__':
+    main()

--- a/run.py
+++ b/run.py
@@ -1,0 +1,8 @@
+from discordbot import main
+from pyannotate_runtime import collect_types
+
+if __name__ == '__main__':
+    collect_types.init_types_collection()
+    with collect_types.collect():
+        main()
+    collect_types.dump_stats('type_info.json')

--- a/type_info.json
+++ b/type_info.json
@@ -1,0 +1,68 @@
+[
+    {
+        "path": "discordbot.py",
+        "line": 43,
+        "func_name": "toggle_debug_mode",
+        "type_comments": [
+            "(bool) -> str"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "discordbot.py",
+        "line": 78,
+        "func_name": "is_common",
+        "type_comments": [
+            "(discord.role.Role) -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "discordbot.py",
+        "line": 88,
+        "func_name": "get_role_names",
+        "type_comments": [
+            "(List[discord.role.Role], function) -> List[str]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "discordbot.py",
+        "line": 129,
+        "func_name": "run_command",
+        "type_comments": [
+            "(discord.message.Message) -> None",
+            "(discord.message.Message) -> pyannotate_runtime.collect_types.NoReturnType"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "discordbot.py",
+        "line": 171,
+        "func_name": "on_ready",
+        "type_comments": [
+            "() -> None",
+            "() -> pyannotate_runtime.collect_types.NoReturnType"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "discordbot.py",
+        "line": 177,
+        "func_name": "on_message",
+        "type_comments": [
+            "(discord.message.Message) -> None",
+            "(discord.message.Message) -> pyannotate_runtime.collect_types.NoReturnType"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "discordbot.py",
+        "line": 195,
+        "func_name": "main",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    }
+]


### PR DESCRIPTION
- [Type hints cheat sheet (Python 3) — Mypy 0.620+dev-3d81dcb57cc61a375ae333bfeab3174322de2441-dirty documentation](http://mypy.readthedocs.io/en/latest/cheat_sheet_py3.html)
- [dropbox/pyannotate: Auto-generate PEP-484 annotations](https://github.com/dropbox/pyannotate)
- [Instagram/MonkeyType: A system for Python that generates static type annotations by collecting runtime types](https://github.com/Instagram/MonkeyType)
- [Python の型アノテーションを自動生成する - Qiita](https://qiita.com/t2y/items/f16a30cb7c4aec8332c2)