### PR TITLE
発言に画像が添付されていたらURLの展開時に画像も送信する

### DIFF
--- a/src/quote.py
+++ b/src/quote.py
@@ -34,4 +34,8 @@ def compose_embed(message):
         text=message.channel.name,
         icon_url=message.guild.icon_url,
     )
+    if message.attachments and message.attachments[0].proxy_url:
+        embed.set_image(
+            url=message.attachments[0].proxy_url
+        )
     return embed


### PR DESCRIPTION
画像は `message.attachments[0].proxy_url` で取得できる。

### テスト項目

以下の条件を満たす発言URLの引用が正常終了する
- [x] 添付ファイルなし
- [x] 画像が添付されている
- [x] 画像以外が添付されている

### 参考URL
- https://discordpy.readthedocs.io/en/latest/api.html#discord.Message.attachments
- https://discordpy.readthedocs.io/en/latest/api.html#discord.Attachment
- https://discordpy.readthedocs.io/en/latest/api.html#discord.Attachment.proxy_url