### PR TITLE
スローモードの自動設定をしないように

### DIFF
--- a/src/discordbot.py
+++ b/src/discordbot.py
@@ -445,7 +445,6 @@ async def qa_thread(message):
     channel_qa = await message.guild.create_text_channel(
         name=message.author.display_name,
         category=message.guild.get_channel(ID.category.issues),
-        slowmode_delay=5,
     )
     await channel_qa.edit(position=0)
     await message.guild.get_channel(ID.channel.question).edit(position=0)


### PR DESCRIPTION
> 時間制限がかかっている間に打ち始めた文章、カウントダウンがゼロになった瞬間にIMEがオフになってひらがなのまま確定されてしまうので、これがあるとものすごく投稿がしにくいです

という意見を受けたため変更