### PR TITLE
チャンネル名のリネームコマンドを修正

### DIFF
--- a/src/cogs/dbp.py
+++ b/src/cogs/dbp.py
@@ -72,6 +72,10 @@ class DiscordBotPortalJP(commands.Cog):
             position=0
         )
 
+    @commands.command()
+    async def name(ctx, *, name):
+        await dispatch_rename(self, ctx.message, name)
+
     @commands.Cog.listener()
     async def on_message(self, message):
         if message.guild.id != self.id:
@@ -85,10 +89,6 @@ class DiscordBotPortalJP(commands.Cog):
             return
         if message.channel.category_id == self.category_issues_id:
             await self.dispatch_thread(message)
-            return
-        if message.content.startswith('name:') and self.can_rename(message):
-            n = len('name:')
-            await self.dispatch_rename(message, name=message.content[n:])
             return
         if self.is_closed_category(message):
             await self.dispatch_reopen(message.channel)

--- a/src/cogs/dbp.py
+++ b/src/cogs/dbp.py
@@ -74,6 +74,9 @@ class DiscordBotPortalJP(commands.Cog):
             return
         await ctx.channel.edit(name=name)
         await ctx.message.delete()
+        await ctx.send(
+            embed=get_default_embed(f'チャンネル名を {neme} に変更しました')
+        )
 
     @commands.Cog.listener()
     async def on_message(self, message):

--- a/src/cogs/dbp.py
+++ b/src/cogs/dbp.py
@@ -67,7 +67,7 @@ class DiscordBotPortalJP(commands.Cog):
             self.is_category_open(ctx.message),
             self.is_category_closed(ctx.message),
         )
-        if not any conditions:
+        if not any(conditions):
             return
         await ctx.channel.edit(name=name)
         await ctx.message.delete()

--- a/src/cogs/dbp.py
+++ b/src/cogs/dbp.py
@@ -72,7 +72,7 @@ class DiscordBotPortalJP(commands.Cog):
         await ctx.channel.edit(name=rename)
         await ctx.message.delete()
         await ctx.send(
-            embed=get_default_embed(f'チャンネル名を {reneme} に変更しました')
+            embed=get_default_embed(f'チャンネル名を {rename} に変更しました')
         )
 
     @commands.Cog.listener()

--- a/src/cogs/dbp.py
+++ b/src/cogs/dbp.py
@@ -63,9 +63,11 @@ class DiscordBotPortalJP(commands.Cog):
 
     @commands.command()
     async def name(ctx, *, name):
-        if self.is_category_closed(message):
-            return
-        if self.is_category_open(ctx.message):
+        conditions = (
+            self.is_category_open(ctx.message),
+            self.is_category_closed(ctx.message),
+        )
+        if not any conditions:
             return
         await ctx.channel.edit(name=name)
         await ctx.message.delete()

--- a/src/cogs/dbp.py
+++ b/src/cogs/dbp.py
@@ -49,7 +49,7 @@ class DiscordBotPortalJP(commands.Cog):
             return
         await self.dispatch_age(message)
 
-    def is_closed_category(self, message):
+    def is_category_closed(self, message):
         if '✅' in message.channel.category.name:
             return True
         if '⛔' in message.channel.category.name:
@@ -63,7 +63,7 @@ class DiscordBotPortalJP(commands.Cog):
 
     @commands.command()
     async def name(ctx, *, name):
-        if self.is_closed_category(message):
+        if self.is_category_closed(message):
             return
         if self.is_category_open(ctx.message):
             return
@@ -87,7 +87,7 @@ class DiscordBotPortalJP(commands.Cog):
         if message.channel.category_id == self.category_issues_id:
             await self.dispatch_thread(message)
             return
-        if self.is_closed_category(message):
+        if self.is_category_closed(message):
             await self.dispatch_reopen(message.channel)
             return
 

--- a/src/cogs/dbp.py
+++ b/src/cogs/dbp.py
@@ -62,17 +62,17 @@ class DiscordBotPortalJP(commands.Cog):
         )
 
     @commands.command()
-    async def name(ctx, *, name):
+    async def name(self, ctx, *, rename):
         conditions = (
             self.is_category_open(ctx.message),
             self.is_category_closed(ctx.message),
         )
         if not any(conditions):
             return
-        await ctx.channel.edit(name=name)
+        await ctx.channel.edit(name=rename)
         await ctx.message.delete()
         await ctx.send(
-            embed=get_default_embed(f'チャンネル名を {neme} に変更しました')
+            embed=get_default_embed(f'チャンネル名を {reneme} に変更しました')
         )
 
     @commands.Cog.listener()

--- a/src/cogs/dbp.py
+++ b/src/cogs/dbp.py
@@ -63,10 +63,6 @@ class DiscordBotPortalJP(commands.Cog):
             return True
         return False
 
-    async def dispatch_rename(self, message, name):
-        await message.channel.edit(name=name)
-        await message.delete()
-
     async def dispatch_age(self, message):
         await message.channel.edit(
             position=0
@@ -74,7 +70,10 @@ class DiscordBotPortalJP(commands.Cog):
 
     @commands.command()
     async def name(ctx, *, name):
-        await dispatch_rename(self, ctx.message, name)
+        if not can_rename():
+            return
+        await ctx.channel.edit(name=name)
+        await ctx.message.delete()
 
     @commands.Cog.listener()
     async def on_message(self, message):

--- a/src/cogs/dbp.py
+++ b/src/cogs/dbp.py
@@ -56,13 +56,6 @@ class DiscordBotPortalJP(commands.Cog):
             return True
         return False
 
-    def can_rename(self, message):
-        if self.is_closed_category(message):
-            return True
-        if message.channel.category_id == self.category_open_id:
-            return True
-        return False
-
     async def dispatch_age(self, message):
         await message.channel.edit(
             position=0
@@ -70,7 +63,9 @@ class DiscordBotPortalJP(commands.Cog):
 
     @commands.command()
     async def name(ctx, *, name):
-        if not can_rename():
+        if self.is_closed_category(message):
+            return
+        if self.is_category_open(ctx.message):
             return
         await ctx.channel.edit(name=name)
         await ctx.message.delete()


### PR DESCRIPTION
## 外部仕様
-  `name:名前` 形式から `/name 名前` 形式に変更
- 変更されたことを通知するように
- その他バグ修正

## 内部仕様
- on_message から command.commands に移行
