### PR TITLE
Actionsを軽量化

### DIFF
--- a/.github/workflows/flake8.yaml
+++ b/.github/workflows/flake8.yaml
@@ -11,11 +11,7 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.7
-    - name: Install pipenv and dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install pipenv
-        pipenv install --dev
+    - name: Install dependencies
+      run: python -m pip install flake8
     - name: Run flake8
-      run: |
-        pipenv run pytest --flake8
+      run: flake8


### PR DESCRIPTION
pipenv install を撤廃して flake8 のインストールと実行のみに